### PR TITLE
Added sound on turret initialisation.

### DIFF
--- a/Turret/Turret_Code.py
+++ b/Turret/Turret_Code.py
@@ -1,4 +1,5 @@
 import numpy as np
+import vlc  # NOTE: pip install python-vlc
 import cv2
 from adafruit_servokit import ServoKit
 
@@ -20,6 +21,10 @@ def main():
     if not cap.isOpened():
         print("--(!) Error opening video capture.")
         exit(0)
+
+    media = vlc.MediaPlayer("Turret_BuildinASentry.mp3")
+    # If the rpi doesn't have a bulitin speaker this may not work.
+    media.play()
 
     print("--(note) Initialisation successful.")
 


### PR DESCRIPTION
I've added a feature that plays sound when the turret is initialised. The package used is called "python-vlc" and can be installed as so: "pip install python-vlc". I'm not sure
if this will work because I'm unsure if the rpi has a builtin speaker, otherwise one may need to be added for it to work.
